### PR TITLE
Fix to allow false to be injected from a source object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 .DS_Store
+.idea/
+ribbons/.idea/
+*.iml

--- a/ribbons/pom.xml
+++ b/ribbons/pom.xml
@@ -15,7 +15,8 @@
     </parent> 
   
   <build>
-		<sourceDirectory>src/main/flex</sourceDirectory> 
+		<sourceDirectory>src/main/flex</sourceDirectory>
+      <testSourceDirectory>src/test/flex</testSourceDirectory>
 		<plugins>
 
 

--- a/ribbons/src/main/flex/com/nirima/ribbons/utils/Binder.as
+++ b/ribbons/src/main/flex/com/nirima/ribbons/utils/Binder.as
@@ -74,7 +74,7 @@ package com.nirima.ribbons.utils
 					isWatching = false;
 				}
 			}
-			else if(target && targetKey && source)
+			else if(target && targetKey)
 			{
 				try
 				{
@@ -116,13 +116,7 @@ package com.nirima.ribbons.utils
 					//t//race("Error : " + error);
 					trace("Error:(Target Undefined)  " + target+"," + targetKey + "," + source + "," + sourceKey);
 				}
-				else if(!source)
-				{
-					//logInfo = new LogInfo( scope);
-					//scope.getLogger().error(LogTypes.SOURCE_UNDEFINED, logInfo);
-					//trace("Error (Source Undefined): " + error);
-					trace("Error (Source Undefined): " + target+"," + targetKey + "," + source + "," + sourceKey);
-				}
+
 			}
 			if(!isWatching)
 			{

--- a/ribbons/src/test/flex/com/nirima/ribbons/injector/TestInjectFromObject.as
+++ b/ribbons/src/test/flex/com/nirima/ribbons/injector/TestInjectFromObject.as
@@ -1,0 +1,60 @@
+package com.nirima.ribbons.injector
+{
+
+import com.nirima.ribbons.injector.helpers.InjectFromObjectTestContext;
+import com.nirima.ribbons.injector.helpers.TestTarget;
+
+import flash.events.EventDispatcher;
+
+import flexunit.framework.TestCase;
+
+public class TestInjectFromObject extends TestCase
+{
+
+    private var context:InjectFromObjectTestContext;
+
+    private var target:TestTarget;
+
+    public function TestInjectFromObject()
+    {
+
+    }
+
+    public function testInjectFromSourceKey():void
+    {
+        TestTarget.initialValue = false;
+        setupContextToInjectObject(true);
+        target = context.createInstance(TestTarget);
+
+        assertTrue(target.propertyFromSourceKey);
+
+        TestTarget.initialValue = true;
+        setupContextToInjectObject(false);
+        target = context.createInstance(TestTarget);
+
+        assertFalse(target.propertyFromSourceKey);
+    }
+
+    public function testInjectFromSourceObject():void
+    {
+        TestTarget.initialValue = false;
+        setupContextToInjectObject(true);
+        target = context.createInstance(TestTarget);
+
+        assertTrue(target.propertyFromSourceObject);
+
+        TestTarget.initialValue = true;
+        setupContextToInjectObject(false);
+        target = context.createInstance(TestTarget);
+
+        assertFalse(target.propertyFromSourceObject);
+    }
+
+    private function setupContextToInjectObject(prop:Object):void
+    {
+        context = new InjectFromObjectTestContext(new EventDispatcher(), prop);
+    }
+
+
+}
+}

--- a/ribbons/src/test/flex/com/nirima/ribbons/injector/helpers/InjectFromObjectTestContext.as
+++ b/ribbons/src/test/flex/com/nirima/ribbons/injector/helpers/InjectFromObjectTestContext.as
@@ -1,0 +1,40 @@
+/**
+ * Test Context for injecting values from an object.
+ */
+package com.nirima.ribbons.injector.helpers
+{
+
+import com.nirima.ribbons.context.Context;
+
+import flash.events.IEventDispatcher;
+
+public class InjectFromObjectTestContext extends Context
+{
+
+    public var sourceProperty:Object;
+
+    public function InjectFromObjectTestContext(dispatcher:IEventDispatcher, valueToInject:Object)
+    {
+        this.sourceProperty = valueToInject;
+        super(dispatcher);
+
+        injector.newRule()
+                .whenInjectingInto(TestTarget).injectProperty("propertyFromSourceKey")
+                .fromSourceKey("sourceProperty").inObject(this);
+
+        injector.newRule()
+                .whenInjectingInto(TestTarget).injectProperty("propertyFromSourceKey")
+                .fromSourceKey("sourceProperty").inObject(this);
+
+        injector.newRule()
+                .whenInjectingInto(TestTarget).injectProperty("propertyFromSourceObject")
+                .fromSourceObject(valueToInject);
+
+        injector.newRule()
+                .whenInjectingInto(TestTarget).injectProperty("propertyFromSourceObject")
+                .fromSourceObject(valueToInject);
+
+
+    }
+}
+}

--- a/ribbons/src/test/flex/com/nirima/ribbons/injector/helpers/TestTarget.as
+++ b/ribbons/src/test/flex/com/nirima/ribbons/injector/helpers/TestTarget.as
@@ -1,0 +1,16 @@
+package com.nirima.ribbons.injector.helpers
+{
+public class TestTarget
+{
+
+    public static var initialValue:Object;
+
+    public var propertyFromSourceKey:Boolean = initialValue;
+    public var propertyFromSourceObject:Boolean = initialValue;
+
+    public function TestTarget()
+    {
+
+    }
+}
+}


### PR DESCRIPTION
Currently you can inject a false value by referencing a source key in an object, but not from a value directly.
